### PR TITLE
add ssh subtasks to access more servers

### DIFF
--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -94,10 +94,25 @@ Capistrano::Configuration.instance(:must_exist).load do
 
   namespace :ssh do
     HiveQueen.default_roles.each do |role_name|
-      task role_name do
-        cmd =  "ssh -t -A -l #{user} #{roles[role_name.to_sym].servers.first}"
-        puts "Executing #{cmd}"
-        exec cmd
+      namespace role_name do
+        task :default do
+          cmd =  "ssh -t -A -l #{user} #{roles[role_name.to_sym].servers.first}"
+          puts "Executing #{cmd}"
+          exec cmd
+        end
+
+        (1..20).each do |i|
+          task i.to_s.to_sym do
+            servers = roles[role_name.to_sym].servers
+            if server = servers[i - 1]
+              cmd =  "ssh -t -A -l #{user} #{servers[i - 1]}"
+              puts "Executing #{cmd}"
+              exec cmd
+            else
+              puts "#{role_name} has only #{servers.count} servers"
+            end
+          end
+        end
       end
     end
 

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.0.1'
+    @@version = '7.1.0'
 
     def self.to_s
       @@version


### PR DESCRIPTION
This allows:

```
cap production ssh:bg:1 # default
cap production ssh:bg:2
cap production ssh:app:20
```

We don't know how many servers exist in the role when we create the tasks, but there doesn't seem to be much cost in having tasks that don't work.