### PR TITLE
ssh tasks: default and console

### DIFF
--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -88,7 +88,6 @@ Capistrano::Configuration.instance(:must_exist).load do
         logger.trace "Using #{db_server} as primary db server"
         role :db, db_server.to_s, :primary => true
       end
-
     end
   end
 
@@ -101,6 +100,11 @@ Capistrano::Configuration.instance(:must_exist).load do
       end
     end
 
+    task :default do
+      cmd = "ssh -t -A -l #{user} #{roles.values.sample.servers.sample}"
+      puts "Executing #{cmd}"
+      exec cmd
+    end
   end
 
   require 'capistrano/hivequeen/setup'

--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -88,38 +88,38 @@ Capistrano::Configuration.instance(:must_exist).load do
         logger.trace "Using #{db_server} as primary db server"
         role :db, db_server.to_s, :primary => true
       end
-    end
-  end
 
-  namespace :ssh do
-    command_format = "ssh -t -A -l %s %s"
-    HiveQueen.default_roles.each do |role_name|
-      task role_name do
-        cmd = command_format % [user, roles[role_name.to_sym].servers.first]
-        puts "Executing #{cmd}"
-        exec cmd
+      namespace :ssh do
+        command_format = "ssh -t -A -l %s %s"
+        env['roles'].keys.each do |role_name|
+          task role_name do
+            cmd = command_format % [user, roles[role_name.to_sym].servers.first]
+            puts "Executing #{cmd}"
+            exec cmd
+          end
+        end
+
+        task :default do
+          cmd = command_format % [user, roles.values.sample.servers.sample]
+          puts "Executing #{cmd}"
+          exec cmd
+        end
       end
-    end
 
-    task :default do
-      cmd = command_format % [user, roles.values.sample.servers.sample]
-      puts "Executing #{cmd}"
-      exec cmd
-    end
-  end
+      namespace :console do
+        command_format = "ssh -t -A -l %s %s 'source /etc/profile; cd /apps/#{HiveQueen.project}/current && bundle exec rails console'"
+        env['roles'].keys.each do |role_name|
+          task role_name do
+            puts "Opening console"
+            exec command_format % [user, roles[role_name.to_sym].servers.first]
+          end
+        end
 
-  namespace :console do
-    command_format = "ssh -t -A -l %s %s 'source /etc/profile; cd /apps/#{HiveQueen.project}/current && bundle exec rails console'"
-    HiveQueen.default_roles.each do |role_name|
-      task role_name do
-        puts "Opening console"
-        exec command_format % [user, roles[role_name.to_sym].servers.first]
+        task :default do
+          puts "Opening console"
+          exec command_format % [user, roles.values.sample.servers.sample]
+        end
       end
-    end
-
-    task :default do
-      puts "Opening console"
-      exec command_format % [user, roles.values.sample.servers.sample]
     end
   end
 

--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -107,6 +107,12 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
   end
 
+  task :console do
+    cmd = "ssh -t -A -l #{user} #{roles.values.sample.servers.sample} cd /apps/#{HiveQueen.project}/current && bundle exec rails console"
+    puts "Opening console"
+    exec cmd
+  end
+
   require 'capistrano/hivequeen/setup'
   require 'capistrano/hivequeen/deploy'
 


### PR DESCRIPTION
Added support for:

* `cap $environment ssh`: opens a remote shell on a random server
* `cap $environment console:$role`: opens a remote Rails console on a server with the given $role
* `cap $environment console`: opens a remote Rails console on a random server