### PR TITLE
Randomly elect server to DB role

### DIFF
--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -82,10 +82,10 @@ Capistrano::Configuration.instance(:must_exist).load do
       unless roles.key?(:db)
         # Prefer a background worker role
         bg = (roles.keys & [:bg, :resque, :sidekiq]).sample
-        db_server = roles[bg].servers.first if roles.key?(bg)
+        db_server = roles[bg].servers.sample if roles.key?(bg)
 
         # Otherwise, use any server
-        db_server ||= roles.values.map{|x| x.servers}.flatten.compact.first
+        db_server ||= roles.values.map{|x| x.servers}.flatten.compact.sample
         logger.trace "Using #{db_server} as primary db server"
         role :db, db_server.to_s, :primary => true
       end

--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -80,8 +80,9 @@ Capistrano::Configuration.instance(:must_exist).load do
 
       # Ensure some server designated as db server
       unless roles.key?(:db)
-        # Prefer the bg server
-        db_server = roles[:bg].servers.first if roles.key?(:bg)
+        # Prefer a background worker role
+        bg = (roles.keys & [:bg, :resque, :sidekiq]).sample
+        db_server = roles[bg].servers.first if roles.key?(bg)
 
         # Otherwise, use any server
         db_server ||= roles.values.map{|x| x.servers}.flatten.compact.first


### PR DESCRIPTION
If an application does not have a DB role, capistrano-hivequeen tries to elect some other server. Currently it uses a deterministic process that prefers to elect from a specially named `bg` role. This change adds `resque` and `sidekiq` to the list of preferred roles, then elects a server at random.