### PR TITLE
Restart app servers in batches of 10

### DIFF
--- a/lib/capistrano/hivequeen/deploy.rb
+++ b/lib/capistrano/hivequeen/deploy.rb
@@ -111,8 +111,12 @@ Capistrano::Configuration.instance.load do
     end
 
     desc "restarts all rails services concurrently"
-    task :restart do
-      run "if [ -x /etc/init.d/rails_services ]; then /etc/init.d/rails_services upgrade; fi"
+    task :restart, max_hosts: 3 do
+      restart_cmd = "if [ -x /etc/init.d/rails_services ]; then /etc/init.d/rails_services upgrade; fi"
+      # Restart non-app servers all-at-once
+      run restart_cmd, roles: (roles.keys - [:app])
+      # Restart app servers in batchs of 3
+      run restart_cmd, max_hosts: 10, roles: :app
     end
   end
 

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.3.1'
+    @@version = '7.4.0'
 
     def self.to_s
       @@version


### PR DESCRIPTION
We’re experiencing long hung connections & dropped requests while
deploying. This should mitigate by restarting app servers 10-at-a-time.

The downside is deploys take longer.

Bump to v7.4.0.

👋 @talaris 