### PR TITLE
Support `canary` param for new deployments and allow canary deploys to bypass `current_commit` consistency checks

### DIFF
--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -15,6 +15,9 @@ Capistrano::Configuration.instance(:must_exist).load do
   # From the command line, use -s override=true to force a deployment
   set :override, false
 
+  # Don't mark deployments as canary deployments by default
+  set :canary, false
+
   # Command to get the changes being deployed
   set :changelog_command do
     `git log #{current_commit}...#{real_revision} --pretty="%n%h %an: %s (%ar)" --stat --no-color`

--- a/lib/capistrano/hivequeen/deploy.rb
+++ b/lib/capistrano/hivequeen/deploy.rb
@@ -22,7 +22,8 @@ Capistrano::Configuration.instance.load do
       params = {
         :task => tasks.join(' '),
         :commit => real_revision,
-        :override => override
+        :override => override,
+        :canary => canary,
       }
 
       if current_commit
@@ -44,7 +45,7 @@ Capistrano::Configuration.instance.load do
 
     desc "[internal] Prompt if deploying the currently running commit, or if tests haven't passed"
     task :check_commit do
-      if environment.to_s == 'production' && !override
+      if environment.to_s == 'production' && !override && !canary
         if current_commit == real_revision
           banner = %q{
  ______                   _     _                          _    ___

--- a/lib/capistrano/hivequeen/deploy.rb
+++ b/lib/capistrano/hivequeen/deploy.rb
@@ -7,11 +7,21 @@ Capistrano::Configuration.instance.load do
   before "deploy:stage", "hivequeen:start"
   before 'hivequeen:start', 'hivequeen:check_commit'
   on :start, "hivequeen:require_environment", :except => HiveQueen.environment_names
+  on :start, "hivequeen:ensure_canary_specifies_hosts"
+
   namespace :hivequeen do
 
     desc "[internal] abort if no environment specified"
     task :require_environment do
       abort "No environment specified." if !exists?(:environment)
+    end
+
+    desc "[internal] abort if we're trying to do a canary deploy but HOSTS hasn't been defined"
+    task :ensure_canary_specifies_hosts do
+      # TODO: I suppose we could randomly select instance(s) in this case
+      if canary && !ENV.key?('HOSTS')
+        abort "You asked to do a canary deployment but didn't specify any hosts! \nPlease invoke like `cap HOSTS=foo.com deploy -s canary=true'"
+      end
     end
 
     desc "[internal] Start a deployment in hivequeen"

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.4.0'
+    @@version = '7.5.0'
 
     def self.to_s
       @@version


### PR DESCRIPTION
#### Background

Canary deploys are possible using out-of-the-box capistrano commands, by specifying a custom host and an explicit revision:

```
cap deploy HOSTS=10.20.30.1 deploy -s sha=abc123
``` 

This works, but it has a couple less-than-ideal consequences due to one of hivequeen's core assumptions. Namely: Hivequeen assumes all application instances are at the same revision. When displaying diffs and comparing proposed changesets, hivequeen always uses the most recently deployed revision as the `current_commit` against which subsequent deploys will be compared, even if the most recent deployment was just to a single instance. This means that, after a canary deploy, subsequent deploys will 1) be diffed against the canary revision, confusing people in slack, and 2) require the `override=true` flag, which is surprising and not even very helpful.

#### Therefore

This is a bare-bones patch to support marking deployments as `canary` deployments in hivequeen.

For this gem, canary deployments are exactly the same as normal ones, except they're allowed to skip current_commit consistency checks (like override deploys are), and must explicitly specify the hosts that should be canaried.

Invocation like this: 

```
cap HOSTS=foo.com staging deploy -s canary=true -s sha abc123
```

...would run the normal deploy task only on host `foo.com`, at revision `abc123`, and will send `canary=true` in the POST request to create the deployment resource with hivequeen. That's it!
