### PR TITLE
[INF-801] Use new field in HQ API for private DNS

### DIFF
--- a/lib/capistrano/hivequeen/capistrano_configuration.rb
+++ b/lib/capistrano/hivequeen/capistrano_configuration.rb
@@ -78,7 +78,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         if exists?(:az)
           servers = servers.select {|s| s['availability_zone'] == az}
         end
-        role(role_name.to_sym) { servers.map {|s| s['public_dns']} }
+        role(role_name.to_sym) { servers.map {|s| s['public_dns'] || s['private_dns']} }
       end
 
       # Ensure some server designated as db server

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.5.0'
+    @@version = '7.6.0'
 
     def self.to_s
       @@version


### PR DESCRIPTION
# What

For instances that don't have a public DNS name we need to fall back to the private DNS name.

# Why

As we move instances into private only subnets we need to be able to connect via private DNS name

# Who
@kickstarter/infrastructure 