### PR TITLE
Add retry+backoff to AWS

### DIFF
--- a/lib/capistrano/hivequeen/ec2_instance_connect.rb
+++ b/lib/capistrano/hivequeen/ec2_instance_connect.rb
@@ -4,7 +4,10 @@ class HiveQueen
   end
 
   def self.ec2_instance_connect_client
-    @ec2_instance_connect_client ||= Aws::EC2InstanceConnect::Client.new
+    @ec2_instance_connect_client ||= Aws::EC2InstanceConnect::Client.new(
+      retry_limit:   5,
+      retry_backoff: -> (c) { sleep(5) },
+    )
   end
 
   def self.ec2_instance_connect(*private_dns)

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.7.1'
+    @@version = '7.7.2'
 
     def self.to_s
       @@version


### PR DESCRIPTION
Aws::EC2InstanceConnect::Client instance needs to retry when we are scaled up