### PR TITLE
[INF-1502] Add filter to only running instances

### DIFF
--- a/lib/capistrano/hivequeen/ec2_instance_connect.rb
+++ b/lib/capistrano/hivequeen/ec2_instance_connect.rb
@@ -15,12 +15,12 @@ class HiveQueen
     ssh_public_key = File.read(File.expand_path('~/.ssh/ksr_ed25519.pub'))
 
     # Get SSH bastion instance(s) from Name tag
-    ssh_params = { filters: [{ name: 'tag:Name', values: %w[ssh-bastion] }] }
+    ssh_params = { filters: [{ name: 'tag:Name', values: %w[ssh-bastion] }, {name: 'instance-state-name', values: %w[running]}] }
     logger.trace("ec2:DescribeInstances #{ssh_params.to_json}")
     bastions = ec2_client.describe_instances(**ssh_params).reservations.map(&:instances).flatten
 
     # Get EC2 instances from private DNS name
-    ec2_params = { filters: [{ name: 'network-interface.private-dns-name', values: private_dns }] }
+    ec2_params = { filters: [{ name: 'network-interface.private-dns-name', values: private_dns }, {name: 'instance-state-name', values: %w[running]}] }
     logger.trace("ec2:DescribeInstances #{ec2_params.to_json}")
     instances = ec2_client.describe_instances(**ec2_params).reservations.map(&:instances).flatten
 

--- a/lib/capistrano/hivequeen/version.rb
+++ b/lib/capistrano/hivequeen/version.rb
@@ -1,6 +1,6 @@
 class HiveQueen
   class Version
-    @@version = '7.7.2'
+    @@version = '7.7.3'
 
     def self.to_s
       @@version


### PR DESCRIPTION
Special thanks to Teddy for raising this error.

# What

Update queries to get list of instances to only return instances that are running

# Why

The follow-up call to send ssh public keys errors if the instance isn't running

# Who
@kickstarter/infrastructure 